### PR TITLE
add alpha animation to dismissed view controller

### DIFF
--- a/Source/TransEasyAnimationController.swift
+++ b/Source/TransEasyAnimationController.swift
@@ -217,6 +217,7 @@ public class EasyDismissAnimationController: NSObject, UIViewControllerAnimatedT
       UIView.addKeyframeWithRelativeStartTime(1/2, relativeDuration: 1/2, animations: {
         fromSnapshot.alpha = 0.0
         toSnapshot.alpha = 1.0
+        fromVC.view.alpha = 0.0
       })
       
     }) { _ in
@@ -318,6 +319,7 @@ public class EasyPopAnimationController: NSObject, UIViewControllerAnimatedTrans
       UIView.addKeyframeWithRelativeStartTime(1/2, relativeDuration: 1/2, animations: {
         fromSnapshot.alpha = 0.0
         toSnapshot.alpha = 1.0
+        fromVC.view.alpha = 0.0
       })
       
     }) { _ in


### PR DESCRIPTION
Right now if you have ex white(or translucent) first VC and black second VC -  when dismiss transition is active, first VC change color after finish dismiss. This merge fix this bug
